### PR TITLE
style: renames project

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -5,7 +5,7 @@ on:
     branches: main
 
 env:
-  REGISTRY_IMAGE: antoniopataro/rinha-go
+  REGISTRY_IMAGE: antoniopataro/rinha-de-backend-2023-q3-go
 
 jobs:
   build:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 bin/
 tmp/
+vendor/
 .env

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This is my late version of the [rinha-de-backend-2023-q3](https://github.com/zan
 #### Results
 You can `git clone` this repo, install [Gatling,](https://gatling.io/open-source/) change the executable with the fixed paths if needed and run the stress test in `/scritps/stress-test`, which is a copy of [the original.](https://github.com/zanfranceschi/rinha-de-backend-2023-q3/tree/main/stress-test)
 
-![image](https://github.com/antoniopataro/rinha-go/assets/87823281/f254f099-c767-4891-8329-a778736cf23f)
+![image](https://github.com/antoniopataro/rinha-de-backend-2023-q3-go/assets/87823281/f254f099-c767-4891-8329-a778736cf23f)
 
 #### Tech
 - go v1.20.6;

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -3,11 +3,11 @@ package main
 import (
 	"fmt"
 
-	"github.com/antoniopataro/rinha-go/internal/config"
-	"github.com/antoniopataro/rinha-go/internal/infra/cache"
-	"github.com/antoniopataro/rinha-go/internal/infra/database"
-	"github.com/antoniopataro/rinha-go/internal/infra/http"
-	"github.com/antoniopataro/rinha-go/pkg/shutdown"
+	"github.com/antoniopataro/rinha-de-backend-2023-q3-go/internal/config"
+	"github.com/antoniopataro/rinha-de-backend-2023-q3-go/internal/infra/cache"
+	"github.com/antoniopataro/rinha-de-backend-2023-q3-go/internal/infra/database"
+	"github.com/antoniopataro/rinha-de-backend-2023-q3-go/internal/infra/http"
+	"github.com/antoniopataro/rinha-de-backend-2023-q3-go/pkg/shutdown"
 	"github.com/google/uuid"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/antoniopataro/rinha-go
+module github.com/antoniopataro/rinha-de-backend-2023-q3-go
 
 go 1.20
 

--- a/internal/config/envs.go
+++ b/internal/config/envs.go
@@ -1,7 +1,7 @@
 package config
 
 import (
-	"github.com/antoniopataro/rinha-go/pkg/envs"
+	"github.com/antoniopataro/rinha-de-backend-2023-q3-go/pkg/envs"
 )
 
 type Envs struct {

--- a/internal/domain/people/repository.go
+++ b/internal/domain/people/repository.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/antoniopataro/rinha-go/internal/infra/cache"
-	"github.com/antoniopataro/rinha-go/internal/infra/database"
+	"github.com/antoniopataro/rinha-de-backend-2023-q3-go/internal/infra/cache"
+	"github.com/antoniopataro/rinha-de-backend-2023-q3-go/internal/infra/database"
 	"github.com/google/uuid"
 )
 

--- a/internal/infra/cache/cache.go
+++ b/internal/infra/cache/cache.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/antoniopataro/rinha-go/internal/config"
+	"github.com/antoniopataro/rinha-de-backend-2023-q3-go/internal/config"
 	"github.com/redis/go-redis/v9"
 )
 

--- a/internal/infra/database/database.go
+++ b/internal/infra/database/database.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/antoniopataro/rinha-go/internal/config"
+	"github.com/antoniopataro/rinha-de-backend-2023-q3-go/internal/config"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 

--- a/internal/infra/http/server.go
+++ b/internal/infra/http/server.go
@@ -1,9 +1,9 @@
 package http
 
 import (
-	"github.com/antoniopataro/rinha-go/internal/domain/people"
-	"github.com/antoniopataro/rinha-go/internal/infra/cache"
-	"github.com/antoniopataro/rinha-go/internal/infra/database"
+	"github.com/antoniopataro/rinha-de-backend-2023-q3-go/internal/domain/people"
+	"github.com/antoniopataro/rinha-de-backend-2023-q3-go/internal/infra/cache"
+	"github.com/antoniopataro/rinha-de-backend-2023-q3-go/internal/infra/database"
 	"github.com/gofiber/fiber/v2"
 )
 

--- a/scripts/stress-test/run-test.sh
+++ b/scripts/stress-test/run-test.sh
@@ -6,7 +6,7 @@
 
 GATLING_BIN_DIR=$HOME/gatling/3.9.5/bin
 
-WORKSPACE=$HOME/documents/projects/personal/rinha-go/scripts/stress-test
+WORKSPACE=$HOME/documents/projects/personal/rinha-de-backend-2023-q3-go/scripts/stress-test
 
 sh $GATLING_BIN_DIR/gatling.sh -rm local -s RinhaBackendSimulation \
     -rd "DESCRICAO" \


### PR DESCRIPTION
- adds vendor/ to .gitignore;
- renames project from `rinha-go` to `rinha-de-backend-2023-q3-go`, so I can keep track of versions in different languages and future editions of the rinha.